### PR TITLE
Fix getting a wrong crange when going to declaration

### DIFF
--- a/lib/ide-haskell-hasktags.coffee
+++ b/lib/ide-haskell-hasktags.coffee
@@ -79,7 +79,7 @@ module.exports = IdeHaskellHasktags =
           left = buffer.getTextInRange [start, crange.start]
           crange2.start.column = left.search(/[\w']*$/)
           right = buffer.getTextInRange [crange.end, end]
-          crange2.end.column += right.search(/[^\w']/)
+          crange2.end.column += right.search(/[^\w']|$/)
 
           symbol = buffer.getTextInRange crange2
           tags = @tags.findTag(symbol)


### PR DESCRIPTION
If the word you want to find is at the end of the line, cannot get a right crange.